### PR TITLE
Modulation Transfer Function Class

### DIFF
--- a/abtem/mtf.py
+++ b/abtem/mtf.py
@@ -1,0 +1,85 @@
+"""Module for applying Modulation Transfer function."""
+import numpy as np
+from abtem.utils import spatial_frequencies
+
+def default_mtf_func(k,c0,c1,c2,c3):
+    """
+    A default MTF function
+    Parameters
+    ----------
+    k : float
+        Spatial frequency
+    c : float
+        Coefficients for function
+    Returns
+    -------
+     : float
+        Result from MTF
+    """
+    return (c0 - c1)/(1 + (k/(2*c2))**np.abs(c3)) + c1
+
+class MTF():
+    """
+    MTF Object for applying a specified MTF function with specified parameters
+    Parameters
+    ----------
+    func: function
+        The Modulation Transfer Function
+    kwargs:
+        Provide the MTF parameters as keyword arguments.
+    measurement: Measurement object
+        The measurement to apply MTF to
+
+    Returns
+    -------
+    measurement: Measurement object
+        The MFT applied measurement
+    """
+    def __init__(self, func=None, **kwargs):
+        if func is None:
+            self.f = default_mtf_func
+        else:
+            self.f = func
+        self.params = kwargs
+
+    def __call__(self, measurement):
+        """
+        Apply a modulation transfer function to the image.
+        Parameters
+        ----------
+        measurement : Measurement object
+            The original Measurement
+        Returns
+        -------
+        measurement: Measurement object
+            The MFT applied measurement
+        """
+        # Get sampling from measurement
+        sampling = []
+        for calibration in measurement.calibrations:
+            if calibration is not None:
+                if calibration.units.lower() in ('angstrom', 'å'):
+                   sampling.append(calibration.sampling)
+        
+        # Get number of gridpoints from measurement
+        if len(measurement.array.shape) == 2:
+            gpts = [ measurement.array.shape[0], measurement.array.shape[1] ]
+        else:
+            gpts = [ measurement.array.shape[1], measurement.array.shape[2] ]
+
+        # Get measurement array   
+        measurement = measurement.copy()
+        img = measurement.array
+
+        # Get spatial frequencies
+        kx,ky = spatial_frequencies(gpts, sampling)
+        k = np.sqrt(kx**2+ky**2)
+
+        # Compute MTF
+        mtf = self.f(k,**self.params)
+
+        # Apply MTF
+        img = np.fft.ifft2(np.fft.fft2(img)*np.sqrt(mtf))
+        measurement.array[:] = (img.real+img.imag)/2
+
+        return measurement

--- a/abtem/mtf.py
+++ b/abtem/mtf.py
@@ -60,7 +60,7 @@ class MTF():
             if calibration is not None:
                 if calibration.units.lower() in ('angstrom', 'å'):
                    sampling.append(calibration.sampling)
-        
+
         # Get number of gridpoints from measurement
         if len(measurement.array.shape) == 2:
             gpts = [ measurement.array.shape[0], measurement.array.shape[1] ]
@@ -72,7 +72,7 @@ class MTF():
         img = measurement.array
 
         # Get spatial frequencies
-        kx,ky = spatial_frequencies(gpts, sampling)
+        kx,ky = spatial_frequencies(gpts,sampling)
         k = np.sqrt(kx**2+ky**2)
 
         # Compute MTF


### PR DESCRIPTION
@schiotz

Class for Modulation Transfer Functions:
- Initialises an MTF object for a given MTF and parameters
- If no function is given, a default MTF has been defined
- Parameters passed via kwargs
- Call attribute obtains the sampling and gpts from a Measurement object and applies the MTF accordingly*

*It is being applied in reciprocal space Å^-1, but should it instead be in the reciprocal of the pixel space pixel^-1? Jakob Schiotz and I were discussing this.