### PR TITLE
Incorrect handling of Fourier transform in MTF.

### DIFF
--- a/abtem/mtf.py
+++ b/abtem/mtf.py
@@ -87,6 +87,6 @@ class MTF:
 
         # Apply MTF
         img = np.fft.ifft2(np.fft.fft2(img) * np.sqrt(mtf))
-        measurement.array[:] = (img.real + img.imag) / 2
+        measurement.array[:] = img.real
 
         return measurement


### PR DESCRIPTION
We (@matthewhelmi and me) think there is a bug in the MTF code, most likely copy-pasted from pyqstem.  It is line 90:
```
measurement.array[:] = (img.real + img.imag) / 2
```

Mathematically, the operation of averaging the real and imaginary part does not make much sense.  In any case, the imaginary part should be zero (within numerical noise): The original image is real, so its Fourier transform will be Hermitian.  The MTF is a real function, so multiplying the two is still Hermitian.   Reverse FFT ofa Hermitian function should then give real data.

So the bug is pretty harmless: the averaging results in dividing the image by two.  We can also see this when we apply the MTF, the intensity of the image is halved.

Edit:  It’s not because the MFT is *real*, but because it is also *Hermitian*, in this case both real and even, since it only depends on the magnitude of k.

Further optimization is possible by using the special FFT and reverse FFT for real data.


