### PR TITLE
Adding Hyperspy support

### DIFF
--- a/abtem/measure.py
+++ b/abtem/measure.py
@@ -700,17 +700,29 @@ class Measurement(AbstractMeasurement):
         signal_type: str
             The signal type alias for some signal type
         """
-        from hyperspy.singals import BaseSignal, Signal1D, Signal2D
-        if self.calibrations is None:
-            sig = BaseSignal(self.array)
+        from hyperspy._signals.signal2d import Signal2D
+        from hyperspy._signals.signal1d import Signal1D
+        signal_shape = np.shape(self.array)
+        axes = []
+        for i, size in zip(self.calibrations, signal_shape):
+            if i is None:
+                axes.append({"offset": 0,
+                             "scale": 1,
+                             "units": "",
+                             "name": "",
+                             "size": size})
+            else:
+                axes.append({"offset": i.offset,
+                            "scale": i.sampling,
+                            "units": i.units,
+                            "name": i.name,
+                            "size": size})
+            print(axes)
+        if len(signal_shape) == 3:
+            # This could change depending on the type of measurement
+            sig = Signal1D(self.array, axes=axes)
         else:
-            signal_shape = np.shape(self.array)
-            axes = [{"offset": i.offset,
-                     "scale": i.sampling,
-                     "units": i.units,
-                     "name": i.name,
-                     "size": size} for i, size in zip(self.calibrations, signal_shape)]
-            sig = Signal2D(self.array, axes)
+            sig = Signal2D(self.array, axes=axes)
         if signal_type is not None:
             sig.set_signal_type(signal_type)
         return sig

--- a/abtem/measure.py
+++ b/abtem/measure.py
@@ -717,7 +717,6 @@ class Measurement(AbstractMeasurement):
                             "units": i.units,
                             "name": i.name,
                             "size": size})
-            print(axes)
         if len(signal_shape) == 3:
             # This could change depending on the type of measurement
             sig = Signal1D(self.array, axes=axes)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ setup(
         'ase',
         'tqdm',
         'psutil'],
+    extras_require={
+        'full': ['hyperspy',
+                 'pyxem']
+    },
     tests_require=['pytest'],
     packages=find_packages(),
     include_package_data=True,

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -5,6 +5,7 @@ from abtem import GridScan, AnnularDetector, PixelatedDetector, Probe, Potential
     Measurement
 from abtem.noise import poisson_noise
 from abtem.measure import center_of_mass
+import hyperspy.api as hs
 
 def test_calibration_coordinates():
     for endpoint in (True, False):
@@ -63,6 +64,17 @@ def test_subtract_measurements(stem_data):
     stem_data -= stem_data
 
 
+@pytest.mark.parametrize("signal_type",[None, "diffraction"])
+def test_to_hyperspy(stem_data, signal_type):
+    for key in stem_data:
+        sig = stem_data[key].to_hyperspy(signal_type=signal_type)
+        assert isinstance(sig, hs.signals.BaseSignal)
+
+
+def test_to_hyperspy_hrtem(hrtem_image):
+    hrtem_image.to_hyperspy()
+
+
 def test_read_write_measurement(tmp_path, stem_data, hrtem_image):
     d = tmp_path / 'sub'
     d.mkdir()
@@ -79,6 +91,20 @@ def test_read_write_measurement(tmp_path, stem_data, hrtem_image):
 
     hrtem_image.write(path)
     Measurement.read(path)
+
+
+def test_write_hspy(tmp_path, stem_data, hrtem_image):
+    d = tmp_path / 'sub'
+    d.mkdir()
+    path = d / 'measurement.hspy'
+
+    stem_data['annular'].write(path, format="hspy")
+
+    stem_data['flexible'].write(path, format="hspy")
+
+    stem_data['pixelated'].write(path, format="hspy")
+
+    hrtem_image.write(path, format="hspy")
 
 
 def test_indexing(stem_data):

--- a/test/test_measure.py
+++ b/test/test_measure.py
@@ -64,7 +64,7 @@ def test_subtract_measurements(stem_data):
     stem_data -= stem_data
 
 
-@pytest.mark.parametrize("signal_type",[None, "diffraction"])
+@pytest.mark.parametrize("signal_type", [None, "diffraction"])
 def test_to_hyperspy(stem_data, signal_type):
     for key in stem_data:
         sig = stem_data[key].to_hyperspy(signal_type=signal_type)


### PR DESCRIPTION
This pull request helps to add in support for Hyperspy as discussed by #27.

This allows for the creation of a `hyperspy.BaseSignal` object using the `to_hyperspy` function. 


For a basic example I have simulated two icosahedral clusters and then created a 4-D STEM simulation. 

![image](https://user-images.githubusercontent.com/41125831/122468029-ce5e9280-cf80-11eb-95c4-c2fe20c1268b.png)


```python 
import ase
from ase.io.cif import read_cif
from abtem import *
from ase.cell import Cell
from abtem.structures import orthogonalize_cell
from ase.cluster.icosahedron import Icosahedron
import matplotlib.pyplot as plt

cluster = Icosahedron("Pd", noshells=3)
cluster2 = Icosahedron("Pd", noshells=3)
cluster2.translate([9,9,9])# moving one of the clusters
cluster.extend(cluster2) # Combining the two clusters
cluster.center(vacuum=20)
cluster = orthogonalize_cell(cluster)
fig, ax1 = plt.subplots(1, 1, figsize=(12,4))


potential = Potential(cluster, 
                      gpts=1024,
                      projection='finite', 
                      slice_thickness=1, 
                      parametrization='kirkland').build(pbar=False)

probe = Probe(energy=200e3,
              semiangle_cutoff=5,
              rolloff=0, defocus=0, Cs=0, focal_spread=0)
gridscan = GridScan(start=[10, 10], end=[50,50], sampling=4)
show_atoms(cluster, ax=ax1, title='Top view')
gridscan.add_to_mpl_plot(ax1)
detector = PixelatedDetector(max_angle=25) # About 10 nm^-1
measurement = probe.scan(gridscan, detector, potential)
signal = measurement.to_hyperspy("diffraction")

print(signal.axes_manager)

signal.plot(vmax= 0.005)
````

<img width="496" alt="image" src="https://user-images.githubusercontent.com/41125831/122467923-aff89700-cf80-11eb-9dce-c90a3d3aeb04.png">

![image](https://user-images.githubusercontent.com/41125831/122467963-bb4bc280-cf80-11eb-9bf4-e888ab172a80.png)

![image](https://user-images.githubusercontent.com/41125831/122467977-c0107680-cf80-11eb-8b34-0c4fe126489f.png)
