### PR TITLE
Bug fix: Use == for string comparison, never "is".

### DIFF
--- a/abtem/measure.py
+++ b/abtem/measure.py
@@ -737,7 +737,7 @@ class Measurement(AbstractMeasurement):
         kwargs:
             Any of the additional parameters for saving a hyperspy dataset
         """
-        if format is "hdf5":
+        if format == "hdf5":
             with h5py.File(path, mode) as f:
                 f.create_dataset('array', data=self.array)
 
@@ -765,7 +765,7 @@ class Measurement(AbstractMeasurement):
                 f.create_dataset('units', (len(units),), 'S10', units)
                 f.create_dataset('name', (len(names),), 'S10', names)
                 f.create_dataset('is_none', data=is_none)
-        elif format is "hspy":
+        elif format == "hspy":
             self.to_hyperspy().save(path, **kwargs)
         else:
             raise ValueError('Format must be one of "hdf5" or "hspy"')


### PR DESCRIPTION
I noticed warnings about this in a notebook (and in the test suite).  Never use the ``is`` operator to compare strings, as it tests for two objects being the same object, not having the same value.  Two strings with the same value will usually be different objects, if they are created in different places.  The code may work, but then it is being saved by "String Interning" where the python byte compiler keeps a table of the most common literal strings in the code, and maps them all to the same object.  This is not reliable, and depends on the Python version and environment.

See https://stackabuse.com/guide-to-string-interning-in-python/


